### PR TITLE
fix: handle terraform plan exit code 2 (changes detected)

### DIFF
--- a/.github/workflows/cd-template.yaml
+++ b/.github/workflows/cd-template.yaml
@@ -55,6 +55,7 @@ jobs:
 
       - name: Terraform Plan for ${{ inputs.terraform_action == 'destroy' && 'Destroy' || 'Apply' }}
         run: |
+          set +e  # Don't exit on error
           # shellcheck disable=SC2086
           terraform \
           -chdir="${{inputs.root_module_folder_relative_path}}" \
@@ -62,6 +63,19 @@ jobs:
           -out=tfplan \
           -input=false \
           ${{ inputs.terraform_action == 'destroy' && '-destroy' || '' }}
+          
+          EXIT_CODE=$?
+          
+          # Exit code 0 = no changes (success)
+          # Exit code 1 = error (failure)
+          # Exit code 2 = changes detected (success for our purposes)
+          if [ $EXIT_CODE -eq 0 ] || [ $EXIT_CODE -eq 2 ]; then
+            echo "✅ Terraform plan succeeded"
+            exit 0
+          else
+            echo "❌ Terraform plan failed with exit code $EXIT_CODE"
+            exit 1
+          fi
 
       - name: Create Module Artifact
         run: |


### PR DESCRIPTION
Fixes the CI/CD pipeline to properly handle terraform plan exit code 2.

Exit code 2 means changes were detected, which is expected and should not fail the workflow. This allows the pipeline to proceed to the approval step.

Without this fix, any terraform plan with changes (exit code 2) would fail the pipeline.